### PR TITLE
fixed Calculix version by obtaining programmatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,13 +239,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.14 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.14 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Leonardo Loures <luvres@hotmail.com>
 
 # sudo apt-get install qemu-user-static binfmt-support
 # sudo update-binfmts --enable qemu-arm
-# sudo update-binfmts --display qemu-arm 
+# sudo update-binfmts --display qemu-arm
 # cp /usr/bin/qemu-aarch64-static .
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -251,14 +251,13 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.13 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.13 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
 	&& sed -i 's/ -m64 $(OPTIONS)//' CalculiX/ccx_2.13/src/Makefile \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/aarch64/xenial-slim/Dockerfile
+++ b/aarch64/xenial-slim/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Leonardo Loures <luvres@hotmail.com>
 
 # sudo apt-get install qemu-user-static binfmt-support
 # sudo update-binfmts --enable qemu-arm
-# sudo update-binfmts --display qemu-arm 
+# sudo update-binfmts --display qemu-arm
 # cp /usr/bin/qemu-aarch64-static .
 COPY qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -247,13 +247,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.12 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.12 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/armhf/Dockerfile
+++ b/armhf/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Leonardo Loures <luvres@hotmail.com>
 
 # sudo apt-get install qemu-user-static binfmt-support
 # sudo update-binfmts --enable qemu-arm
-# sudo update-binfmts --display qemu-arm 
+# sudo update-binfmts --display qemu-arm
 # cp /usr/bin/qemu-arm-static .
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 
@@ -251,14 +251,13 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.13 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.13 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
 	&& sed -i 's/ -m64 $(OPTIONS)//' CalculiX/ccx_2.13/src/Makefile \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/armhf/xenial-slim/Dockerfile
+++ b/armhf/xenial-slim/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Leonardo Loures <luvres@hotmail.com>
 
 # sudo apt-get install qemu-user-static binfmt-support
 # sudo update-binfmts --enable qemu-arm
-# sudo update-binfmts --display qemu-arm 
+# sudo update-binfmts --display qemu-arm
 # cp /usr/bin/qemu-arm-static .
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 
@@ -247,13 +247,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.12 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.12 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -104,9 +104,9 @@ RUN \
 	-DCMAKE_INSTALL_PREFIX:PATH=$FREECAD \
   \
 	&& make -j$(nproc) \
-	&& make install 
+	&& make install
 #  # Clean
-#	&& cd && rm $MAKEDIR -fR 
+#	&& cd && rm $MAKEDIR -fR
 
 
 ### OCCT 7.1.0p1 -> libfreeimage-dev libfreeimage3 libtbb-dev libtbb2
@@ -131,7 +131,7 @@ RUN \
 	&& make -j$(nproc) \
 	&& make install \
   # Clean
-	&& cd && rm $MAKEDIR -fR 
+	&& cd && rm $MAKEDIR -fR
 
 ### Netgen 5.3.1
 #----------------
@@ -157,9 +157,9 @@ RUN \
 	&& make -j$(nproc) \
 	&& make install \
   \
-	&& cp -fR libsrc $FREECAD/libsrc 
+	&& cp -fR libsrc $FREECAD/libsrc
 #  # Clean
-#	&& cd && rm netgen -fR 
+#	&& cd && rm netgen -fR
 
 ### OCCT 7.2.0 -> libfreeimage-dev libfreeimage3 libtbb-dev libtbb2
 #--------------
@@ -182,7 +182,7 @@ RUN \
 		-DCMAKE_BUILD_TYPE=Release \
 	\
 	&& make -j$(nproc) \
-	&& make install 
+	&& make install
 #  # Clean
 #	&& cd && rm $MAKEDIR -fR
 
@@ -210,9 +210,9 @@ RUN \
 #	&& make -j$(nproc) \
 #	&& make install \
 #  \
-#	&& cp -fR libsrc $FREECAD/libsrc 
+#	&& cp -fR libsrc $FREECAD/libsrc
 #  # Clean
-#	&& cd && rm netgen -fR 
+#	&& cd && rm netgen -fR
 
 ### Netgen 5.3.1
 #----------------
@@ -249,7 +249,7 @@ RUN \
 #	&& make -j$(nproc) \
 #	&& make install \
 #  \
-#	&& cp -fR libsrc $FREECAD/libsrc 
+#	&& cp -fR libsrc $FREECAD/libsrc
 #  # Clean
 #	&&
 
@@ -278,9 +278,9 @@ RUN \
 			-DCMAKE_BUILD_TYPE=Release \
 			-DCMAKE_VERBOSE_MAKEFILE=ON \
   \
-	&& make install 
+	&& make install
 #  # Clean
-#	&& cd && rm $MAKEDIR -fR 
+#	&& cd && rm $MAKEDIR -fR
 
 
 ### VTK 8.0.1
@@ -308,9 +308,9 @@ RUN \
 			-DVTK_RENDERING_BACKEND=None \
   \
 	&& make -j$(nproc) \
-	&& make install 
+	&& make install
 #  # Clean
-#	&& cd && rm $MAKEDIR -fR 
+#	&& cd && rm $MAKEDIR -fR
 
 
 ### FreeCAD latest Github commit
@@ -318,7 +318,7 @@ RUN \
 # get FreeCAD
 RUN \
 	cd \
-	&& git clone https://github.com/FreeCAD/FreeCAD 
+	&& git clone https://github.com/FreeCAD/FreeCAD
 
 ## building FreeCAD
 RUN \
@@ -330,13 +330,13 @@ RUN \
 		-DCMAKE_INSTALL_PREFIX:PATH=$FREECAD \
 		-DOCC_INCLUDE_DIR=$FREECAD/include/opencascade \
 		-DNETGEN_ROOT=$FREECAD \
-		-DBUILD_FEM_NETGEN=ON 
+		-DBUILD_FEM_NETGEN=ON
 
 # Make FreeCAD
 RUN \
 	cd \
 	&& cd build \
-	&& make -j$(nproc) 
+	&& make -j$(nproc)
 
 
 # Install FreeCAD
@@ -344,7 +344,7 @@ RUN \
 #	cd \
 #	&& cd build \
 #	&& make install \
-#	&& ln -s /opt/FreeCAD/bin/FreeCAD /usr/bin/freecad-git 
+#	&& ln -s /opt/FreeCAD/bin/FreeCAD /usr/bin/freecad-git
 
 # Clean
 #RUN \
@@ -353,17 +353,16 @@ RUN \
 #		# 79M
 #		$FREECAD/doc/* \
 #		# 128M
-#		$FREECAD/share/doc/* 
+#		$FREECAD/share/doc/*
 
 
-### Calculix 2.12 and CGX
+### Calculix and CGX
 #-------------------------
 #RUN \
-#	ccx_VERSION=2.12 \
-#  \
-#	&& cd \
+#	cd \
 #	&& git clone https://github.com/luvres/calculix.git \
 #	&& cd calculix/ \
+#    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 #	&& ./install \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \
@@ -381,7 +380,7 @@ RUN \
 #		$pack_calculix \
 #		cmake \
 #  \#  # gmsh 2.11.0
-#	&& apt-get -t jessie-backports install -y gmsh 
+#	&& apt-get -t jessie-backports install -y gmsh
 #	&& apt-get autoremove -y \
 #  \
 #	&& apt-get install -y \

--- a/build/sid/Dockerfile
+++ b/build/sid/Dockerfile
@@ -244,13 +244,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-#  ### Calculix 2.12 and CGX
+#  ### Calculix and CGX
 #  #-------------------------
-#	&& ccx_VERSION=2.12 \
-#  \
 #	&& cd \
 #	&& git clone https://github.com/luvres/calculix.git \
 #	&& cd calculix/ \
+#   && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 #	&& ./install \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/build/stretch/Dockerfile
+++ b/build/stretch/Dockerfile
@@ -239,13 +239,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-#  ### Calculix 2.12 and CGX
+#  ### Calculix and CGX
 #  #-------------------------
-#	&& ccx_VERSION=2.12 \
-#  \
 #	&& cd \
 #	&& git clone https://github.com/luvres/calculix.git \
 #	&& cd calculix/ \
+#   && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 #	&& ./install \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 #	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -244,13 +244,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.13 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.13 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \

--- a/xenial-slim/Dockerfile
+++ b/xenial-slim/Dockerfile
@@ -239,13 +239,12 @@ RUN \
 	  # 128M
 		$FREECAD/share/doc/* \
   \
-  ### Calculix 2.13 and CGX
+  ### Calculix and CGX
   #-------------------------
-	&& ccx_VERSION=2.13 \
-  \
 	&& cd \
 	&& git clone https://github.com/luvres/calculix.git \
 	&& cd calculix/ \
+    && ccx_VERSION=$(cat ./install | grep "export PROGSDIR=" | sed 's/^.*CalculiX-//') \
 	&& ./install \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/ccx_${ccx_VERSION} /usr/bin/ccx \
 	&& cp $HOME/CalculiX-${ccx_VERSION}/bin/cgx /usr/bin/cgx \


### PR DESCRIPTION
Building docker images was failing due to outdated Calculix version. This PR fixes the problem as long as Calculix `install` script structure is intact. 